### PR TITLE
Initialization of variables in desat

### DIFF
--- a/pobm/_ResultsClasses.py
+++ b/pobm/_ResultsClasses.py
@@ -31,6 +31,10 @@ class ODIMeasureResult:
     begin: np.array
     end: np.array
 
+    def __post_init__(self):
+        self.begin = np.array(self.begin) if isinstance(self.begin, list) else self.begin
+        self.end = np.array(self.end) if isinstance(self.end, list) else self.end
+
     def __str__(self):
         return str({"ODI": self.ODI, "begin": self.begin.flatten().tolist(), "end": self.end.flatten().tolist()})
 
@@ -60,6 +64,10 @@ class DesaturationsMeasuresResults:
 
     begin: np.array
     end: np.array
+
+    def __post_init__(self):
+        self.begin = np.array(self.begin) if isinstance(self.begin, list) else self.begin
+        self.end = np.array(self.end) if isinstance(self.end, list) else self.end
 
     def __str__(self):
         desat_measures = dict(dataclasses.asdict(self))

--- a/pobm/obm/desat.py
+++ b/pobm/obm/desat.py
@@ -136,7 +136,7 @@ class DesaturationsMeasures:
             self.begin = begin
             self.end = end
             self.min_desat = [x + np.argmin(signal[x:y]) for (x, y) in zip(begin, end)]
-            self.counter_desat = []
+            self.counter_desat = [1]*len(self.begin)
 
         self.__remove_small_desats()
 


### PR DESCRIPTION
Minor fix because empty self.desat_counter was breaking features extraction.

Put a post_init in DesaturationsMeasuresResults and ODIMeasureResult if class is initialized with a list instead of array. It was raising an error without it.